### PR TITLE
Fix button spacing and sidebar visibility

### DIFF
--- a/notes.html
+++ b/notes.html
@@ -108,7 +108,8 @@
     .editor-header { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px; padding: 10px 12px; border-bottom: 1px solid var(--border); background: var(--panel); }
     .title-input { font-size: 1.2rem; padding: 10px 12px; border-radius: 12px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); outline: none; width: 100%; }
 
-    .editor-toolbar { display: flex; flex-wrap: wrap; gap: 6px; padding: 10px 12px; border-bottom: 1px solid var(--border); background: var(--panel); position: sticky; top: 56px; z-index: 4; }
+    .editor-toolbar { display: flex; flex-wrap: nowrap; gap: 6px; padding: 8px 12px; border-bottom: 1px solid var(--border); background: var(--panel); position: sticky; top: 56px; z-index: 4; overflow-x: auto; white-space: nowrap; align-items: center; }
+    .editor-toolbar .btn { flex: 0 0 auto; }
     .editor { display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 0; }
     .pane { min-height: 0; overflow: auto; }
 
@@ -162,8 +163,8 @@
       .md-pane { border-left: none; border-top: 1px solid var(--border); }
     }
     @media (max-width: 900px) {
-      .app { grid-template-columns: 1fr; grid-template-areas: "header" "main"; }
-      .sidebar { display: none; }
+      .app { grid-template-columns: 1fr; grid-template-rows: 56px auto 1fr; grid-template-areas: "header" "sidebar" "main"; }
+      .sidebar { display: block; border-right: none; border-bottom: 1px solid var(--border); position: sticky; top: 56px; height: calc(100vh - 56px); overflow: auto; }
     }
   </style>
 </head>


### PR DESCRIPTION
Reduce editor toolbar height and prevent sidebar auto-hiding on small screens to improve notes visibility and sidebar stability.

The editor toolbar previously wrapped buttons, consuming excessive vertical space and obscuring the notes area. Additionally, the sidebar was set to `display: none` on screens under 900px, leading to unexpected disappearance. These changes ensure the editor area remains fully visible and the sidebar is consistently accessible by making the toolbar a single-row scroller and adjusting the small-screen media query for the sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab240f01-f2c7-416a-831d-b49f944187c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab240f01-f2c7-416a-831d-b49f944187c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

